### PR TITLE
change logging

### DIFF
--- a/ExperimentLog_Doc.ipynb
+++ b/ExperimentLog_Doc.ipynb
@@ -38,7 +38,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# temporary fix for notebook - https://github.com/ipython/ipython/issues/8282\n",
+    "import logging\n",
+    "logging.getLogger().handlers = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -47,8 +60,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:root:No stream mouse registered; creating a new blank entry\n",
-      "2016-02-15 10:20:26,217: No stream mouse registered; creating a new blank entry\n"
+      "02-15 18:12 [WARNI]  No stream mouse registered; creating a new blank entry\n"
      ]
     }
    ],

--- a/experimentlog.py
+++ b/experimentlog.py
@@ -24,14 +24,22 @@ def str_to_np(s):
     return n
 
 # enable logging
-logging.basicConfig(level=logging.DEBUG, 
-                    format='%(asctime)s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    filename="experiment.log")
-                    
-stream_logger = logging.StreamHandler() 
-stream_logger.setFormatter(logging.Formatter('%(asctime)s: %(message)s'))
-logging.getLogger().addHandler(stream_logger)
+logFormatter = logging.Formatter(fmt="%(asctime)s [%(levelname)-5.5s]  %(message)s",
+                                 datefmt='%m-%d %H:%M')
+
+rootLogger = logging.getLogger()
+rootLogger.setLevel(logging.DEBUG)
+
+fileHandler = logging.FileHandler("experiment.log")
+fileHandler.setLevel(logging.DEBUG)
+fileHandler.setFormatter(logFormatter)
+rootLogger.addHandler(fileHandler)
+
+consoleHandler = logging.StreamHandler()
+consoleHandler.setLevel(logging.INFO)
+consoleHandler.setFormatter(logFormatter)
+rootLogger.addHandler(consoleHandler)
+
 
 class ExperimentException(Exception):
     pass

--- a/extract.py
+++ b/extract.py
@@ -7,14 +7,6 @@ import os
 from collections import defaultdict
 import pandas as pd
 
-logging.basicConfig(level=logging.DEBUG, 
-                    format='%(asctime)s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    filename="experiment.log")
-                    
-stream_logger = logging.StreamHandler() 
-stream_logger.setFormatter(logging.Formatter('%(asctime)s: %(message)s'))
-logging.getLogger().addHandler(stream_logger)
 
 class AutoVivification(dict):
     """Implementation of perl's autovivification feature."""

--- a/report.py
+++ b/report.py
@@ -9,9 +9,7 @@ import cStringIO
 def pretty_json(x):
     return ("\n"+json.dumps(x, sort_keys=True, indent=4, separators=(',', ': '))+"\n").replace("\n", "\n        ")
     
-logging.basicConfig(level=logging.DEBUG, 
-                    format='%(asctime)s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M')
+
 
 def string_report(cursor):
     c = cStringIO.StringIO()


### PR DESCRIPTION
Init in done in experimentlog.py only.

2 handlers: 
- file handler to "experiment.log" at DEBUG level
- console handler at INFO level

There is default handler in ipython notebook that will catch the message being generated, so it is removed at the beginning of the notebook. Workaround for a fix that might come later, see https://github.com/ipython/ipython/issues/8282
